### PR TITLE
Add Modrinth upload helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,25 @@ Jachou
 # Statistics
 
 <img src="https://bstats.org/signatures/bukkit/ReanimateMC.svg" alt="BStats">
+## Automated Modrinth Upload
+
+A helper script is provided in `scripts/upload_to_modrinth.sh` to publish a new plugin version directly to Modrinth. The script uses the Modrinth HTTP API and requires `curl` to be installed.
+
+### Usage
+
+```bash
+export MODRINTH_TOKEN=your_token_here
+export PROJECT_ID=your_project_id
+export VERSION_NAME="Release 1.0"
+export VERSION_NUMBER="1.0.0"
+# Optional settings
+export GAME_VERSIONS_JSON='["1.20.1"]'
+export LOADERS_JSON='["spigot"]'
+export VERSION_TYPE=release
+export CHANGELOG_FILE=changelog.txt
+export JAR_PATH=target/ReanimateMC.jar
+
+./scripts/upload_to_modrinth.sh
+```
+
+The script uploads the specified JAR file and creates a new version on Modrinth with the provided metadata.

--- a/scripts/upload_to_modrinth.sh
+++ b/scripts/upload_to_modrinth.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -euo pipefail
+
+# Script to upload a new version of the plugin to Modrinth using its HTTP API.
+# Environment variables:
+#   MODRINTH_TOKEN - API token (required)
+#   PROJECT_ID     - Modrinth project ID (required)
+#   VERSION_NAME   - Version display name (required)
+#   VERSION_NUMBER - Version number (required)
+#   GAME_VERSIONS_JSON - JSON array of supported Minecraft versions (default ["1.20.1"])
+#   LOADERS_JSON       - JSON array of loaders (default ["spigot"])
+#   VERSION_TYPE       - release, beta, or alpha (default release)
+#   CHANGELOG_FILE     - optional changelog file
+#   FEATURED           - whether the release should be featured (default false)
+#   JAR_PATH           - path to plugin jar (default target/ReanimateMC.jar)
+
+JAR_PATH=${JAR_PATH:-target/ReanimateMC.jar}
+PROJECT_ID=${PROJECT_ID:?Project ID not set}
+MODRINTH_TOKEN=${MODRINTH_TOKEN:?API token not set}
+VERSION_NAME=${VERSION_NAME:?Version name not set}
+VERSION_NUMBER=${VERSION_NUMBER:?Version number not set}
+GAME_VERSIONS_JSON=${GAME_VERSIONS_JSON:-["1.20.1"]}
+LOADERS_JSON=${LOADERS_JSON:-["spigot"]}
+VERSION_TYPE=${VERSION_TYPE:-release}
+CHANGELOG_FILE=${CHANGELOG_FILE:-}
+FEATURED=${FEATURED:-false}
+
+if [ ! -f "$JAR_PATH" ]; then
+  echo "Jar file $JAR_PATH does not exist" >&2
+  exit 1
+fi
+
+CHANGELOG=""
+if [ -n "$CHANGELOG_FILE" ]; then
+  CHANGELOG=$(sed 's/"/\\"/g' "$CHANGELOG_FILE")
+fi
+
+read -r -d '' JSON <<EOF_JSON
+{
+  "project_id": "$PROJECT_ID",
+  "name": "$VERSION_NAME",
+  "version_number": "$VERSION_NUMBER",
+  "changelog": "$CHANGELOG",
+  "game_versions": $GAME_VERSIONS_JSON,
+  "version_type": "$VERSION_TYPE",
+  "loaders": $LOADERS_JSON,
+  "featured": $FEATURED,
+  "dependencies": [],
+  "file_parts": ["file"],
+  "primary_file": "file"
+}
+EOF_JSON
+
+curl -fSL \
+  -H "Authorization: $MODRINTH_TOKEN" \
+  -F "data=$JSON;type=application/json" \
+  -F "file=@$JAR_PATH" \
+  https://api.modrinth.com/v2/version


### PR DESCRIPTION
## Summary
- add a shell script to publish releases to Modrinth via API
- document how to use the script in README

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6849ca7a46c0832eacd4df6a5857af1d