### PR TITLE
Add Totem support

### DIFF
--- a/src/main/java/fr/jachou/reanimatemc/ReanimateMC.java
+++ b/src/main/java/fr/jachou/reanimatemc/ReanimateMC.java
@@ -69,6 +69,7 @@ public final class ReanimateMC extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new ExecutionListener(koManager), this);
         getServer().getPluginManager().registerEvents(new LootListener(), this);
         getServer().getPluginManager().registerEvents(new PlayerKOListener(koManager), this);
+        getServer().getPluginManager().registerEvents(new TotemListener(koManager), this);
 
         // Enregistrement de la commande principale
         getCommand("reanimatemc").setExecutor(new ReanimateMCCommand(koManager, configGui));

--- a/src/main/java/fr/jachou/reanimatemc/listeners/PlayerDamageListener.java
+++ b/src/main/java/fr/jachou/reanimatemc/listeners/PlayerDamageListener.java
@@ -4,6 +4,7 @@ import fr.jachou.reanimatemc.ReanimateMC;
 import fr.jachou.reanimatemc.managers.KOManager;
 import fr.jachou.reanimatemc.utils.Utils;
 import org.bukkit.Color;
+import org.bukkit.Material;
 import org.bukkit.Particle;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
@@ -31,6 +32,13 @@ public class PlayerDamageListener implements Listener {
         if (Utils.isNPC(player)) return;
 
         if (player.getHealth() - event.getFinalDamage() <= 0) {
+            // If the player holds a Totem of Undying in either hand, let the
+            // vanilla mechanic handle it (no KO state applied)
+            if (player.getInventory().getItemInMainHand().getType() == Material.TOTEM_OF_UNDYING ||
+                    player.getInventory().getItemInOffHand().getType() == Material.TOTEM_OF_UNDYING) {
+                return;
+            }
+
             event.setCancelled(true);
             if (!koManager.isKO(player)) {
                 koManager.setKO(player);

--- a/src/main/java/fr/jachou/reanimatemc/listeners/TotemListener.java
+++ b/src/main/java/fr/jachou/reanimatemc/listeners/TotemListener.java
@@ -1,0 +1,56 @@
+package fr.jachou.reanimatemc.listeners;
+
+import fr.jachou.reanimatemc.managers.KOManager;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+
+public class TotemListener implements Listener {
+    private final KOManager koManager;
+    public TotemListener(KOManager koManager) {
+        this.koManager = koManager;
+    }
+
+    @EventHandler
+    public void onUseTotem(PlayerInteractEvent event) {
+        Action action = event.getAction();
+        if (action != Action.RIGHT_CLICK_AIR && action != Action.RIGHT_CLICK_BLOCK) {
+            return;
+        }
+
+        Player player = event.getPlayer();
+        if (!koManager.isKO(player)) {
+            return;
+        }
+
+        ItemStack item = event.getItem();
+        if (item == null || item.getType() != Material.TOTEM_OF_UNDYING) {
+            return;
+        }
+
+        event.setCancelled(true);
+        // Consume one totem from the hand used
+        if (event.getHand() == EquipmentSlot.HAND) {
+            ItemStack hand = player.getInventory().getItemInMainHand();
+            if (hand.getAmount() <= 1) {
+                player.getInventory().setItemInMainHand(null);
+            } else {
+                hand.setAmount(hand.getAmount() - 1);
+            }
+        } else if (event.getHand() == EquipmentSlot.OFF_HAND) {
+            ItemStack hand = player.getInventory().getItemInOffHand();
+            if (hand.getAmount() <= 1) {
+                player.getInventory().setItemInOffHand(null);
+            } else {
+                hand.setAmount(hand.getAmount() - 1);
+            }
+        }
+
+        koManager.revive(player);
+    }
+}


### PR DESCRIPTION
## Summary
- allow Totem of Undying to bypass KO
- allow KO players to right-click with a Totem to self-revive

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68556e6bedd0832e91a0cc8b5314586d