### PR TITLE
Fix KO seat height and countdown display

### DIFF
--- a/src/main/java/fr/jachou/reanimatemc/managers/KOManager.java
+++ b/src/main/java/fr/jachou/reanimatemc/managers/KOManager.java
@@ -80,6 +80,7 @@ public class KOManager {
                         ReanimateMC.lang.get("actionbar_ko_countdown", "time", String.valueOf(sec))
                 );
                 label.setCustomName(ChatColor.RED + "KO - " + sec + "s");
+                label.teleport(player.getLocation().add(0, 2.1, 0));
             } else {
                 label.remove();
             }
@@ -175,7 +176,7 @@ public class KOManager {
      * The stand is spawned slightly lower to avoid floating.
      */
     private ArmorStand createMount(org.bukkit.Location loc) {
-        org.bukkit.Location seatLoc = loc.clone().subtract(0, 1.0, 0);
+        org.bukkit.Location seatLoc = loc.clone().subtract(0, 0.5, 0);
         ArmorStand seat = (ArmorStand) loc.getWorld().spawnEntity(seatLoc, EntityType.ARMOR_STAND);
         seat.setInvisible(true);
         seat.setSmall(true);

--- a/src/main/resources/lang/en.yml
+++ b/src/main/resources/lang/en.yml
@@ -35,7 +35,7 @@ actionbar_crawl_enabled: "Crawl mode enabled!"
 actionbar_crawl_disabled: "Crawl mode disabled!"
 loot_opening: "Opening %player%’s inventory…"
 loot_no_permission: "You do not have permission to loot KO’d players."
-ko_shift_click_cancelled: "You cannot shift-click while you're ko."
+ko_shift_click_cancelled: "You decided to endure."
 suicide_start: "Giving up... you will die in %time%s"
 suicide_complete: "You gave up..."
 

--- a/src/main/resources/lang/fr.yml
+++ b/src/main/resources/lang/fr.yml
@@ -35,7 +35,7 @@ actionbar_crawl_enabled: "Mode rampant activé !"
 actionbar_crawl_disabled: "Mode rampant désactivé !"
 loot_opening: "Ouverture de l’inventaire de %player%…"
 loot_no_permission: "Vous n'avez pas la permission de piller les joueurs KO."
-ko_shift_click_cancelled: "Vous ne pouvez pas faire un shift click en état K.O."
+ko_shift_click_cancelled: "Vous décidez de tenir bon."
 suicide_start: "Abandon... vous mourrez dans %time%s"
 suicide_complete: "Vous avez abandonné..."
 


### PR DESCRIPTION
## Summary
- align KO mount seat so players don't sink underground
- keep countdown label above the player
- update message when a player stops sneaking during suicide

## Testing
- `mvn -q package -DskipTests` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68590f1d3a5c832eb3f040ef778ba85c