### PR TITLE
Fix KO timer for offline players

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ ReanimateMC is a revolutionary plugin that transforms Minecraft’s conventional
 ### New Features
 - KO state now persists if a player disconnects.
 - KO players can press the swap-hand key to send a distress signal that places a beacon and alerts allies.
+- Offline KO timer now continues counting down and will kill the player if it expires before they reconnect.
 
 
 ## Commands

--- a/src/main/java/fr/jachou/reanimatemc/listeners/PlayerConnectionListener.java
+++ b/src/main/java/fr/jachou/reanimatemc/listeners/PlayerConnectionListener.java
@@ -25,9 +25,11 @@ public class PlayerConnectionListener implements Listener {
     @EventHandler
     public void onJoin(PlayerJoinEvent event) {
         Player player = event.getPlayer();
-        int remaining = koManager.pullOfflineKO(player.getUniqueId());
+        long remaining = koManager.pullOfflineKO(player.getUniqueId());
         if (remaining > 0) {
-            Bukkit.getScheduler().runTaskLater(ReanimateMC.getInstance(), () -> koManager.setKO(player, remaining), 1L);
+            Bukkit.getScheduler().runTaskLater(ReanimateMC.getInstance(), () -> koManager.setKO(player, (int) remaining), 1L);
+        } else if (remaining == 0) {
+            player.setHealth(0);
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure players remain KO offline until timer expires
- kill players on join if timer expired
- document offline KO timer behavior

## Testing
- `mvn -q -DskipTests package` *(fails: Could not resolve maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6887a217869c832eae06a0ab17f1c666