### PR TITLE
Respect damage cancellation from other plugins

### DIFF
--- a/src/main/java/fr/jachou/reanimatemc/listeners/PlayerDamageListener.java
+++ b/src/main/java/fr/jachou/reanimatemc/listeners/PlayerDamageListener.java
@@ -9,9 +9,9 @@ import org.bukkit.Particle;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageEvent;
-import org.bukkit.event.entity.EntityDamageEvent.DamageModifier;
 
 public class PlayerDamageListener implements Listener {
     private final KOManager koManager;
@@ -20,7 +20,7 @@ public class PlayerDamageListener implements Listener {
         this.koManager = koManager;
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onPlayerDamage(EntityDamageEvent event) {
         if (!(event.getEntity() instanceof Player player))
             return;
@@ -31,13 +31,7 @@ public class PlayerDamageListener implements Listener {
         if (Utils.isNPC(player)) return;
 
         double currentHealth = player.getHealth();
-        double finalDamage = 0.0;
-
-        for (DamageModifier modifier : DamageModifier.values()) {
-            if (event.isApplicable(modifier)) {
-                finalDamage += event.getDamage(modifier);
-            }
-        }
+        double finalDamage = event.getFinalDamage();
 
         if (finalDamage >= currentHealth) {
             // If the player holds a Totem of Undying in either hand, let the


### PR DESCRIPTION
## Summary
- run damage listener after other plugins and ignore cancelled events so godmode-style protections work
- use final damage value provided by Bukkit rather than manual modifier sum

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3173442c832ea72bf1d69db9e84a