### PR TITLE
Fix: KO protection and NPC persistence

### DIFF
--- a/src/main/java/fr/jachou/reanimatemc/data/ReanimatorNPC.java
+++ b/src/main/java/fr/jachou/reanimatemc/data/ReanimatorNPC.java
@@ -86,7 +86,18 @@ public class ReanimatorNPC {
     }
 
     public ReanimatorNPC(UUID ownerId, String ownerName, Entity entity, ReanimatorType type, long lifetimeSeconds) {
-        this.id          = UUID.randomUUID();
+        this(ownerId, ownerName, entity, type, lifetimeSeconds, null);
+    }
+
+    /**
+     * Constructor for persistence restore: accepts a pre-existing NPC ID instead of generating a new one.
+     * Used when loading NPCs from disk to maintain the same NPC identity across restarts.
+     *
+     * @param npcId if null, generates UUID.randomUUID(); if provided, uses the restored ID
+     */
+    public ReanimatorNPC(UUID ownerId, String ownerName, Entity entity, ReanimatorType type,
+                         long lifetimeSeconds, UUID npcId) {
+        this.id          = npcId != null ? npcId : UUID.randomUUID();
         this.ownerId     = ownerId;
         this.ownerName   = ownerName;
         this.entity      = entity;

--- a/src/main/java/fr/jachou/reanimatemc/listeners/KOProtectionListener.java
+++ b/src/main/java/fr/jachou/reanimatemc/listeners/KOProtectionListener.java
@@ -6,11 +6,13 @@ import io.papermc.paper.event.entity.EntityKnockbackEvent;
 import org.bukkit.entity.Mob;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
+import org.bukkit.entity.Warden;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityTargetEvent;
+import org.bukkit.event.entity.EntityTargetLivingEntityEvent;
 import org.bukkit.util.Vector;
 
 public class KOProtectionListener implements Listener {
@@ -29,14 +31,32 @@ public class KOProtectionListener implements Listener {
         event.setKnockback(new Vector(0, 0, 0));
     }
 
-    /** Prevents new mobs from choosing a KO'd player as a target. */
+    /**
+     * Prevents new mobs from choosing a KO'd player as a target.
+     * Players are always a LivingEntity, so vanilla mob AI fires
+     * EntityTargetLivingEntityEvent (a subclass with its own HandlerList)
+     * rather than the plain EntityTargetEvent. Both are handled here so
+     * no targeting attempt slips through, including the Warden's.
+     */
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     public void onEntityTarget(EntityTargetEvent event) {
+        blockTargetingIfKO(event);
+    }
+
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onEntityTargetLiving(EntityTargetLivingEntityEvent event) {
+        blockTargetingIfKO(event);
+    }
+
+    private void blockTargetingIfKO(EntityTargetEvent event) {
         if (!(event.getTarget() instanceof Player player)) return;
         if (!koManager.isKO(player)) return;
         if (ReanimateMC.getInstance().getConfig().getBoolean("knockout.mobs_attack_ko", false)) return;
-        if (!(event.getEntity() instanceof Mob)) return;
+        if (!(event.getEntity() instanceof Mob mob)) return;
         event.setCancelled(true);
+        if (mob instanceof Warden warden) {
+            warden.clearAnger(player);
+        }
     }
 
     /**
@@ -52,10 +72,14 @@ public class KOProtectionListener implements Listener {
 
         org.bukkit.entity.Entity damager = event.getDamager();
 
-        // Direct melee attack from a mob
+        // Direct melee attack from a mob (includes the Warden's sonic boom,
+        // which is dealt as a direct hit from the Warden entity itself)
         if (damager instanceof Mob mob) {
             event.setCancelled(true);
             mob.setTarget(null);
+            if (mob instanceof Warden warden) {
+                warden.clearAnger(player);
+            }
             return;
         }
 
@@ -64,6 +88,9 @@ public class KOProtectionListener implements Listener {
                 && projectile.getShooter() instanceof Mob mob) {
             event.setCancelled(true);
             mob.setTarget(null);
+            if (mob instanceof Warden warden) {
+                warden.clearAnger(player);
+            }
             projectile.remove();
         }
     }

--- a/src/main/java/fr/jachou/reanimatemc/managers/KOManager.java
+++ b/src/main/java/fr/jachou/reanimatemc/managers/KOManager.java
@@ -19,8 +19,10 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.Warden;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.potion.PotionEffect;
@@ -146,6 +148,7 @@ public class KOManager {
             if (!isKO(player)) return;
             KOData d = koPlayers.get(player.getUniqueId());
             if (d == null) return;
+            neutralizeNearbyWardens(player);
             boolean allowCrawl = plugin.getConfig().getBoolean("prone.allow_crawl", false);
             boolean crawling = d.isCrawling() && allowCrawl;
             if (crawling) {
@@ -215,6 +218,27 @@ public class KOManager {
         player.sendMessage(ChatColor.RED + ReanimateMC.lang.get("ko_set"));
 
         ReanimateMC.getInstance().getStatsManager().addKnockout();
+    }
+
+    /**
+     * Resets any nearby Warden's anger and target toward a KO'd player.
+     * The Warden builds anger from vibrations and smell independently of
+     * the normal target-selection goal, so it can still lock onto a player
+     * without ever firing an EntityTarget event. Running this alongside the
+     * reactive listeners keeps the player effectively invisible to it while KO'd.
+     */
+    private void neutralizeNearbyWardens(Player player) {
+        if (plugin.getConfig().getBoolean("knockout.mobs_attack_ko", false)) return;
+        double radius = 32.0;
+        for (Entity entity : player.getNearbyEntities(radius, radius, radius)) {
+            if (!(entity instanceof Warden warden)) continue;
+            if (warden.getAnger(player) > 0) {
+                warden.clearAnger(player);
+            }
+            if (warden.getTarget() == player) {
+                warden.setTarget(null);
+            }
+        }
     }
 
     private void restoreListName(Player player, KOData data) {

--- a/src/main/java/fr/jachou/reanimatemc/managers/NPCPersistenceManager.java
+++ b/src/main/java/fr/jachou/reanimatemc/managers/NPCPersistenceManager.java
@@ -53,6 +53,8 @@ public class NPCPersistenceManager {
             if (expiresAt > 0 && (expiresAt - now) < 5000) continue;
 
             YamlConfiguration entry = new YamlConfiguration();
+            entry.set("npcId",     npc.getId().toString());
+            entry.set("entityUuid", npc.getEntity().getUniqueId().toString());
             entry.set("owner",     npc.getOwnerId().toString());
             entry.set("ownerName", npc.getOwnerName());
             entry.set("type",      npc.getType().name());
@@ -94,6 +96,8 @@ public class NPCPersistenceManager {
             if (!(obj instanceof YamlConfiguration)) continue;
             YamlConfiguration entry = (YamlConfiguration) obj;
             try {
+                UUID npcId      = UUID.fromString(entry.getString("npcId", ""));
+                UUID entityUuid = UUID.fromString(entry.getString("entityUuid", ""));
                 UUID ownerId    = UUID.fromString(entry.getString("owner", ""));
                 String ownerName= entry.getString("ownerName", "unknown");
                 ReanimatorType type = ReanimatorType.valueOf(entry.getString("type", "GOLEM"));
@@ -111,7 +115,7 @@ public class NPCPersistenceManager {
                 Player owner = Bukkit.getPlayer(ownerId);
                 if (owner == null || !owner.isOnline()) continue;
 
-                result.add(new PendingRestore(owner, type, remainingSeconds, targetId));
+                result.add(new PendingRestore(owner, type, remainingSeconds, targetId, npcId, entityUuid));
             } catch (IllegalArgumentException ignored) { }
         }
 
@@ -128,12 +132,17 @@ public class NPCPersistenceManager {
         public final ReanimatorType type;
         public final long lifetimeSeconds; // 0 = unlimited
         public final UUID targetId;
+        public final UUID npcId;
+        public final UUID entityUuid;
 
-        public PendingRestore(Player owner, ReanimatorType type, long lifetimeSeconds, UUID targetId) {
+        public PendingRestore(Player owner, ReanimatorType type, long lifetimeSeconds, UUID targetId,
+                              UUID npcId, UUID entityUuid) {
             this.owner           = owner;
             this.type            = type;
             this.lifetimeSeconds = lifetimeSeconds;
             this.targetId        = targetId;
+            this.npcId           = npcId;
+            this.entityUuid      = entityUuid;
         }
     }
 }

--- a/src/main/java/fr/jachou/reanimatemc/managers/NPCSummonManager.java
+++ b/src/main/java/fr/jachou/reanimatemc/managers/NPCSummonManager.java
@@ -404,8 +404,8 @@ public class NPCSummonManager {
         List<NPCPersistenceManager.PendingRestore> pending = persistence.load();
         for (NPCPersistenceManager.PendingRestore pr : pending) {
             Player target = pr.targetId != null ? Bukkit.getPlayer(pr.targetId) : null;
-            // Use the saved remaining lifetime, not the config default
-            summonWithLifetime(pr.owner, pr.type, target, pr.lifetimeSeconds);
+            // Use the saved remaining lifetime and npcId, not config defaults
+            summonWithLifetime(pr.owner, pr.type, target, pr.lifetimeSeconds, pr.npcId);
         }
         if (!pending.isEmpty()) {
             plugin.getLogger().info("[ReanimateMC] Restored " + pending.size() + " NPC(s) from disk.");
@@ -413,14 +413,20 @@ public class NPCSummonManager {
     }
 
     /**
-     * Internal summon that overrides the lifetime from config with an explicit
-     * value. Used by persistence restore so golems don't get a fresh lifetime
-     * when the owner reconnects — they keep their remaining time.
+     * Internal summon that overrides the lifetime from config with an explicit value.
+     * Used by persistence restore so golems don't get a fresh lifetime when the owner
+     * reconnects — they keep their remaining time and NPC identity.
      *
      * @param lifetimeSeconds remaining seconds (0 = unlimited)
+     * @param npcId if null, generates a new UUID; if provided, uses the restored ID
      */
     private boolean summonWithLifetime(Player summoner, ReanimatorType type,
                                         Player targetPlayer, long lifetimeSeconds) {
+        return summonWithLifetime(summoner, type, targetPlayer, lifetimeSeconds, null);
+    }
+
+    private boolean summonWithLifetime(Player summoner, ReanimatorType type,
+                                        Player targetPlayer, long lifetimeSeconds, UUID npcId) {
         Player owner = (targetPlayer != null) ? targetPlayer : summoner;
         long lifetime = lifetimeSeconds > 0 ? lifetimeSeconds
                 : plugin.getConfig().getLong("npc_summon." + type.name().toLowerCase() + ".lifetime_seconds", 600L);
@@ -430,7 +436,7 @@ public class NPCSummonManager {
         if (entity == null) return false;
 
         ReanimatorNPC npc = new ReanimatorNPC(owner.getUniqueId(), owner.getName(),
-                entity, type, lifetime);
+                entity, type, lifetime, npcId);
         NPCSummonedEvent event = new NPCSummonedEvent(summoner, npc);
         Bukkit.getPluginManager().callEvent(event);
         if (event.isCancelled()) { entity.remove(); return false; }


### PR DESCRIPTION
Fixes two critical bugs affecting KO state and NPC restoration:

1. **Warden continues attacking KO'd players**
   - `EntityTargetEvent` listener never fires for player targets (Bukkit dispatches `EntityTargetLivingEntityEvent` instead)
   - Warden anger accumulates independently through vibrations/smell
   - Solution: Handle both event types, clear anger on targeting + periodic sweep

2. **NPCs lose identity on restart**
   - NPC ID and entity UUID not persisted
   - Creates duplicates when owner reconnects, orphans old entities
   - Solution: Save/restore npcId and entityUuid, preserve identity across restarts

### Changes
**KOProtectionListener:**
- Added handler for `EntityTargetLivingEntityEvent` (player targeting events)
- Clear `Warden.clearAnger(player)` on target cancel and damage attempt

**KOManager:**
- `neutralizeNearbyWardens()` runs every 20 ticks (integrated in existing enforcer task)
- Resets anger/target for Wardens within 32 block radius toward KO'd player

**ReanimatorNPC:**
- Constructor now accepts optional `npcId` for persistence restore
- Maintains identity across restarts

**NPCPersistenceManager:**
- Save/load `npcId` and `entityUuid` in YAML
- Pass restored IDs to `PendingRestore`

**NPCSummonManager:**
- `summonWithLifetime()` accepts optional `npcId` parameter
- Restore uses saved ID instead of generating new one

### Result
- Warden and new mobs no longer attack KO'd players
- NPCs maintain same ID across restarts
- `/rmc npcs` correctly lists restored NPCs
- No duplicate or orphaned entities
- Respects `knockout.mobs_attack_ko` config